### PR TITLE
chore(docker): mount /app/artifacts to host for persistent local ML artifacts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - ./media:/app/media
       - ./.coveragerc:/app/.coveragerc:ro
       - ./pytest.ini:/app/pytest.ini:ro
+      - ./artifacts:/app/artifacts
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
chore(docker): mount /app/artifacts to host for persistent local ML artifacts