### PR TITLE
Chore/add initial ops smoke test

### DIFF
--- a/tests/test_ops_smoke.py
+++ b/tests/test_ops_smoke.py
@@ -48,6 +48,5 @@ def test_root_urlpatterns_include_media_static_when_debug_true():
     reloaded = importlib.reload(urls_module)
     media_prefix = settings.MEDIA_URL.lstrip("/")
     assert any(
-        str(pattern.pattern).startswith(f"^{media_prefix}")
-        for pattern in reloaded.urlpatterns
+        str(pattern.pattern).startswith(f"^{media_prefix}") for pattern in reloaded.urlpatterns
     )


### PR DESCRIPTION
## Summary
Adds initial smoke-test coverage for the new ops UI entrypoints and routing behavior.

## Changes
- Added authenticated smoke test for `GET /ops/` redirecting to the queue route
- Added queue page smoke test for `GET /ops/queue/` returning `200`
- Asserted queue template usage (`ops/queue.html`) in the queue smoke test
- Added `DEBUG=True` URLConf test to verify media static patterns are appended in root routes

## Why
Provides fast, baseline confidence that ops routing and page rendering are wired correctly, and closes patch coverage gaps flagged by Codecov.

## Testing
- Added/updated tests in `tests/test_ops_smoke.py`
- Smoke tests validate redirect behavior, successful page render, template wiring, and debug URL branch behavior

## Notes
This PR focuses on minimal coverage and routing/template correctness only; deeper ops workflow behavior will be covered in follow-up tests.