### PR TITLE
fix(ops-htmx): wrap notes partial with #notes-panel for stable outerHTML swaps

### DIFF
--- a/policylens/apps/ops/templates/ops/partials/notes_list.html
+++ b/policylens/apps/ops/templates/ops/partials/notes_list.html
@@ -1,34 +1,36 @@
 <!-- path: policylens/apps/ops/templates/ops/partials/notes_list.html -->
-<div class="d-flex align-items-center justify-content-between mb-2">
-  <div class="h6 mb-0">Notes</div>
+<div id="notes-panel">
+  <div class="d-flex align-items-center justify-content-between mb-2">
+    <div class="h6 mb-0">Notes</div>
+  </div>
+
+  <form
+    hx-post="{% url 'ops:htmx-add-note' claim_id=claim.id %}"
+    hx-target="#notes-panel"
+    hx-swap="outerHTML"
+    class="mb-3"
+    method="post"
+  >
+    {% csrf_token %}
+    <div class="mb-2">
+      <textarea name="body" class="form-control" rows="3" placeholder="Add a note for reviewers">{{ form.body.value|default:"" }}</textarea>
+      {% if form.errors.body %}
+        <div class="text-danger small mt-1">{{ form.errors.body.0 }}</div>
+      {% endif %}
+    </div>
+    <button class="btn btn-primary btn-sm" type="submit">Add note</button>
+  </form>
+
+  {% if claim.notes.all|length == 0 %}
+    <div class="text-muted">No notes yet.</div>
+  {% else %}
+    <div class="vstack gap-2">
+      {% for n in claim.notes.all %}
+        <div class="border rounded p-2 bg-white">
+          <div class="small text-muted">{{ n.created_at }} · {{ n.created_by|default:"(unknown)" }}</div>
+          <div>{{ n.body }}</div>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
 </div>
-
-<form
-  hx-post="{% url 'ops:htmx-add-note' claim_id=claim.id %}"
-  hx-target="#notes-panel"
-  hx-swap="outerHTML"
-  class="mb-3"
-  method="post"
->
-  {% csrf_token %}
-  <div class="mb-2">
-    <textarea name="body" class="form-control" rows="3" placeholder="Add a note for reviewers">{{ form.body.value|default:"" }}</textarea>
-    {% if form.errors.body %}
-      <div class="text-danger small mt-1">{{ form.errors.body.0 }}</div>
-    {% endif %}
-  </div>
-  <button class="btn btn-primary btn-sm" type="submit">Add note</button>
-</form>
-
-{% if claim.notes.all|length == 0 %}
-  <div class="text-muted">No notes yet.</div>
-{% else %}
-  <div class="vstack gap-2">
-    {% for n in claim.notes.all %}
-      <div class="border rounded p-2 bg-white">
-        <div class="small text-muted">{{ n.created_at }} · {{ n.created_by|default:"(unknown)" }}</div>
-        <div>{{ n.body }}</div>
-      </div>
-    {% endfor %}
-  </div>
-{% endif %}


### PR DESCRIPTION
## Summary
This PR fixes the Ops HTMX notes partial so `outerHTML` swaps target a stable, self-contained root element.

## Changes
- Wrapped `ops/partials/notes_list.html` in a root `<div id="notes-panel">`.
- Kept the add-note HTMX form behavior unchanged:
  - `hx-post` to `ops:htmx-add-note`
  - `hx-target="#notes-panel"`
  - `hx-swap="outerHTML"`
  - `method="post"` with `{% csrf_token %}`
- Preserved existing note rendering and form validation error display.

## Why
`hx-swap="outerHTML"` requires the target element to exist as a concrete root in the returned partial. Without a stable `#notes-panel` wrapper, swaps can be brittle or fail depending on surrounding template structure.

## Validation
- `tests/test_ops_claim_detail.py` passes.
- `tests/test_ops_htmx_note.py` passes (including success and validation paths).