### PR TITLE
feat(ops-htmx): improve decision flow errors and order decision history

### DIFF
--- a/policylens/apps/ops/views_htmx.py
+++ b/policylens/apps/ops/views_htmx.py
@@ -11,12 +11,13 @@ from __future__ import annotations
 
 from django.contrib.auth.decorators import login_required
 from django.core.files.uploadedfile import UploadedFile
+from django.db.models import Prefetch
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, render
 
 from policylens.apps.claims import services
 from policylens.apps.claims.ml.scoring import ModelNotReady, score_claim
-from policylens.apps.claims.models import Claim
+from policylens.apps.claims.models import Claim, ReviewDecision
 from policylens.apps.ops.forms import AddNoteForm, DecisionForm
 
 
@@ -95,7 +96,6 @@ def htmx_add_decision(request: HttpRequest, claim_id: int) -> HttpResponse:
     """Record a decision and return refreshed decisions partial."""
     claim = get_object_or_404(Claim, pk=claim_id)
     form = DecisionForm(request.POST or None)
-    error = None
 
     if request.method == "POST" and form.is_valid():
         try:
@@ -105,12 +105,15 @@ def htmx_add_decision(request: HttpRequest, claim_id: int) -> HttpResponse:
                 notes=form.cleaned_data.get("notes") or "",
                 actor=_actor(request),
             )
+            form = DecisionForm()
         except services.DomainRuleViolation as exc:
-            error = str(exc)
+            form.add_error(None, str(exc))
 
-    claim = Claim.objects.prefetch_related("decisions").get(pk=claim_id)
+    claim = Claim.objects.prefetch_related(
+        Prefetch("decisions", queryset=ReviewDecision.objects.order_by("-decided_at"))
+    ).get(pk=claim_id)
     return render(
         request,
         "ops/partials/decisions_list.html",
-        context={"claim": claim, "form": DecisionForm(), "error": error},
+        context={"claim": claim, "form": form},
     )

--- a/tests/test_ops_htmx_note.py
+++ b/tests/test_ops_htmx_note.py
@@ -297,7 +297,7 @@ def test_htmx_add_decision_success_creates_decision(client):
 
 @pytest.mark.django_db
 def test_htmx_add_decision_domain_rule_violation_sets_error(client, monkeypatch):
-    """Domain rule failures should be rendered as decision error context."""
+    """Domain rule failures should be returned as form non-field errors."""
     user = User.objects.create_user(username="ops_htmx_user_decision_rule", password="password123")
     client.force_login(user)
 
@@ -333,4 +333,56 @@ def test_htmx_add_decision_domain_rule_violation_sets_error(client, monkeypatch)
 
     assert resp.status_code == 200
     assert captured["template_name"] == "ops/partials/decisions_list.html"
-    assert captured["context"]["error"] == "Claim is already decided."
+    form = captured["context"]["form"]
+    assert form.data["decision"] == ReviewDecision.Decision.APPROVE
+    assert form.data["notes"] == "Approve now"
+    assert form.non_field_errors() == ["Claim is already decided."]
+
+
+@pytest.mark.django_db
+def test_htmx_add_decision_returns_decisions_in_reverse_decided_at_order(client, monkeypatch):
+    """Rendered decision history should be sorted by newest decision first."""
+    user = User.objects.create_user(username="ops_htmx_user_decision_order", password="password123")
+    client.force_login(user)
+
+    policy = PolicyFactory()
+    claim = Claim.objects.create(
+        policy=policy,
+        claim_type=Claim.Type.CLAIM,
+        priority=Claim.Priority.NORMAL,
+        summary="HTMX decision history order",
+        created_by="seed",
+        status=Claim.Status.NEW,
+    )
+
+    services.add_decision(
+        claim=claim,
+        decision=ReviewDecision.Decision.REQUEST_INFO,
+        notes="First decision",
+        actor=user.username,
+    )
+    services.add_decision(
+        claim=claim,
+        decision=ReviewDecision.Decision.REQUEST_INFO,
+        notes="Second decision",
+        actor=user.username,
+    )
+
+    captured = {}
+
+    def fake_render(request, template_name, context):
+        captured["template_name"] = template_name
+        captured["context"] = context
+        return HttpResponse("ok")
+
+    monkeypatch.setattr(views_htmx, "render", fake_render)
+
+    url = reverse("ops:htmx-add-decision", kwargs={"claim_id": claim.id})
+    resp = client.get(url, HTTP_HX_REQUEST="true")
+
+    assert resp.status_code == 200
+    assert captured["template_name"] == "ops/partials/decisions_list.html"
+    decisions = list(captured["context"]["claim"].decisions.all())
+    assert len(decisions) == 2
+    assert decisions[0].notes == "Second decision"
+    assert decisions[1].notes == "First decision"


### PR DESCRIPTION
## Summary
This PR improves the Ops HTMX decision endpoint by tightening error UX and making decision history ordering deterministic for rendering.

## What changed
- Updated `htmx_add_decision` in `policylens/apps/ops/views_htmx.py` to:
  - Preserve submitted form input when decision recording fails due to a domain rule.
  - Surface domain failures as non-field form errors (`form.add_error(None, ...)`) instead of separate context error strings.
  - Reset the decision form only after successful submission.
- Updated decision history query to return newest-first:
  - `Prefetch("decisions", queryset=ReviewDecision.objects.order_by("-decided_at"))`

## Why
- Improves HTMX decision flow usability by keeping user-entered values on failed submissions.
- Standardizes how errors are represented in forms, making template handling cleaner.
- Ensures consistent decision history ordering for current and future UI rendering.

## Tests
Added/updated tests in `tests/test_ops_htmx_note.py`:
- Verifies domain-rule violations preserve posted values and return a non-field form error.
- Verifies decisions are returned in reverse chronological order for history rendering.

## Validation
- `black` run on touched files
- `ruff check` passed
- `pytest -q tests/test_ops_htmx_note.py` passed (11 tests)