### PR TITLE
fix(ops): pass form context for decisions and notes on claim detail

### DIFF
--- a/policylens/apps/ops/templates/ops/claim_detail.html
+++ b/policylens/apps/ops/templates/ops/claim_detail.html
@@ -72,13 +72,13 @@
 
       <div class="card shadow-sm mb-3">
         <div class="card-body">
-          {% include "ops/partials/notes_list.html" %}
+          {% include "ops/partials/notes_list.html" with form=note_form %}
         </div>
       </div>
 
       <div class="card shadow-sm mb-3">
         <div class="card-body">
-          {% include "ops/partials/decisions_list.html" %}
+          {% include "ops/partials/decisions_list.html" with form=decision_form %}
         </div>
       </div>
 

--- a/policylens/apps/ops/views.py
+++ b/policylens/apps/ops/views.py
@@ -22,6 +22,7 @@ from policylens.apps.claims.models import (
     ReviewDecision,
 )
 from policylens.apps.claims.queue import build_queue_queryset
+from policylens.apps.ops.forms import AddNoteForm, DecisionForm
 
 
 @login_required
@@ -65,7 +66,7 @@ def claim_detail_view(request: HttpRequest, claim_id: int) -> HttpResponse:
         ).prefetch_related(
             Prefetch("documents", queryset=ClaimDocument.objects.order_by("uploaded_at")),
             Prefetch("notes", queryset=InternalNote.objects.order_by("created_at")),
-            Prefetch("decisions", queryset=ReviewDecision.objects.order_by("decided_at")),
+            Prefetch("decisions", queryset=ReviewDecision.objects.order_by("-decided_at")),
             Prefetch("audit_events", queryset=AuditEvent.objects.order_by("created_at")),
         ),
         pk=claim_id,
@@ -74,5 +75,10 @@ def claim_detail_view(request: HttpRequest, claim_id: int) -> HttpResponse:
     return render(
         request,
         "ops/claim_detail.html",
-        context={"page_title": f"Claim #{claim.id}", "claim": claim},
+        context={
+            "page_title": f"Claim #{claim.id}",
+            "claim": claim,
+            "note_form": AddNoteForm(),
+            "decision_form": DecisionForm(),
+        },
     )


### PR DESCRIPTION
## Summary
This PR fixes initial claim detail rendering by passing explicit form context into the notes and decisions partials.

## Problem
The decisions dropdown rendered blank on first page load because `decisions_list.html` expected a `form` object (`form.fields.decision.choices`), but no `form` was provided from `claim_detail_view`.

## Changes
- Updated `policylens/apps/ops/views.py`:
  - Added `note_form = AddNoteForm()` and `decision_form = DecisionForm()` to claim detail context.
  - Updated decisions prefetch ordering to `-decided_at` for consistent newest-first history display.
- Updated `policylens/apps/ops/templates/ops/claim_detail.html`:
  - Passes `form=note_form` into `ops/partials/notes_list.html`.
  - Passes `form=decision_form` into `ops/partials/decisions_list.html`.

## Impact
- Decisions select options now render correctly on initial page load.
- Notes/decisions partials receive the expected form contract consistently between full-page and HTMX renders.
- Decision history ordering is consistent with HTMX decision partial behavior.

## Validation
- `tests/test_ops_claim_detail.py` passed
- `tests/test_ops_htmx_decision.py` passed
- `tests/test_ops_htmx_note.py` passed