### PR TITLE
feat(customer-ui): add customer document upload template

### DIFF
--- a/policylens/templates/customer/document_upload.html
+++ b/policylens/templates/customer/document_upload.html
@@ -1,0 +1,28 @@
+{% extends "customer/base.html" %}
+
+{% block title %}Upload document | PolicyLens{% endblock %}
+
+{% block customer_content %}
+  <section class="card">
+    <h2>Upload document</h2>
+    <p class="muted">Upload a file for claim {{ claim.id }}. Upload is restricted to claims you own.</p>
+
+    {% if error %}
+      <div class="alert">{{ error }}</div>
+    {% endif %}
+
+    <form method="post" enctype="multipart/form-data" class="form">
+      {% csrf_token %}
+
+      <div class="field">
+        <label for="file">File</label>
+        <input id="file" name="file" type="file" required />
+      </div>
+
+      <div class="button-row">
+        <button class="button" type="submit">Upload</button>
+        <a class="button button-secondary" href="{% url 'customer:claim_detail' claim_id=claim.id %}">Cancel</a>
+      </div>
+    </form>
+  </section>
+{% endblock %}


### PR DESCRIPTION
**Summary**
This PR adds the customer-facing document upload page for claim detail workflows in the customer portal.

**What Changed**
- Added upload template:
  - [document_upload.html](/Users/adrianadewunmi/VSCODE/Claims-Fraud-Risk-Scoring-Project/policylens/templates/customer/document_upload.html)
- Template extends `customer/base.html` for consistent customer portal layout.
- Added multipart file upload form (`enctype="multipart/form-data"`) with CSRF token.
- Added required file input field for document selection.
- Added inline error banner rendering when backend returns an `error` message.
- Added “Upload” submit action and “Cancel” link back to customer claim detail.

**Behavior Notes**
- Upload form is scoped to a specific claim (`claim.id`) and aligned with ownership-restricted customer flows.
- Validation/error feedback is surfaced directly in the template for failed submissions.
- No API contract changes; this is UI/template wiring for existing customer upload view behavior.

**Why**
This completes the customer upload UI path so customers can attach supporting documents from the portal with clear validation feedback and navigation.

**Validation**
- Manual checks for:
  - initial form render
  - required file input behavior
  - error message display when file is missing
  - cancel navigation back to claim detail