### PR TITLE
feat(core): add idempotent create_demo_users management command

### DIFF
--- a/policylens/apps/core/management/create_demo_users.py
+++ b/policylens/apps/core/management/create_demo_users.py
@@ -31,6 +31,7 @@ from policylens.apps.claims.models import Claim, Policy, PolicyHolder, SlaClock
 @dataclass(frozen=True)
 class DemoUserSpec:
     """Definition of a demo user and its role group membership."""
+
     username: str
     email: str
     group_name: str
@@ -117,7 +118,9 @@ class Command(BaseCommand):
         self.stdout.write(f"created_reviewer_queue_claims={created_reviewer}")
         self.stdout.write(f"created_customer_owned_claims={created_customer}")
         self.stdout.write(f"total_reviewer_queue_claims={self._reviewer_queue_claim_count()}")
-        self.stdout.write(f"total_customer_owned_claims={self._customer_owned_claim_count(customer_user)}")
+        self.stdout.write(
+            f"total_customer_owned_claims={self._customer_owned_claim_count(customer_user)}"
+        )
 
     def _ensure_groups(self) -> tuple[Group, Group, Group]:
         """Ensure the standard Week 6 groups exist."""
@@ -173,7 +176,9 @@ class Command(BaseCommand):
 
     def _customer_owned_claim_count(self, customer_user: Any) -> int:
         """Count customer-owned claims created by this demo seed for the given customer user."""
-        return Claim.objects.filter(policy__holder__email=customer_user.email, created_by=customer_user.username).count()
+        return Claim.objects.filter(
+            policy__holder__email=customer_user.email, created_by=customer_user.username
+        ).count()
 
     def _ensure_reviewer_queue_claims(self, policy: Policy) -> int:
         """


### PR DESCRIPTION
## Description

This PR introduces an idempotent Django management command to provision deterministic demo data for PolicyLens.

### What’s included

- Adds `create_demo_users` command at `policylens/apps/core/management/create_demo_users.py`
- Creates or updates demo users:
  - `demo_admin`
  - `demo_reviewer`
  - `demo_customer`
- Ensures required role groups exist (`admin`, `reviewer`, `customer`) and applies membership
- Resets demo user passwords on each run for predictable access
- Ensures seed policy/policyholder records exist for demo flows
- Seeds enough claims to demonstrate pagination in:
  - reviewer queue (`/ops/queue/`)
  - customer claim list (`/customer/`)
- Creates SLA clock records for newly seeded claims
- Prints deterministic summary output (users, passwords, created counts, totals)

### Behavior

- Safe to run repeatedly
- Only creates missing claims up to configured minimum thresholds
- Avoids duplicate over-seeding while keeping demo data consistent across runs

### How to run

```bash
python manage.py create_demo_users
```

### Expected outcome

Running the command results in usable demo credentials and sufficient seeded claims to reliably show multi-page reviewer/customer views in demos.