### PR TITLE
Chore/add production settings hardening

### DIFF
--- a/policylens/config/settings.py
+++ b/policylens/config/settings.py
@@ -2,7 +2,7 @@
 """
 Django settings for PolicyLens.
 
-Week 7 Day 2 adds production hardening for running behind a reverse proxy (Nginx):
+Sprint 7 Day 2 adds production hardening for running behind a reverse proxy (Nginx):
 - Secure cookie flags suitable for HTTPS termination
 - CSRF trusted origins for deployed hosts
 - Proxy header support so Django correctly detects HTTPS and host
@@ -59,7 +59,9 @@ def _split_csv(value: str) -> list[str]:
 
 SECRET_KEY = env("DJANGO_SECRET_KEY")
 if not SECRET_KEY:
-    raise RuntimeError("DJANGO_SECRET_KEY is required. Set it in .env or environment variables.")
+    raise RuntimeError(  # pragma: no cover
+        "DJANGO_SECRET_KEY is required. Set it in .env or environment variables."
+    )
 
 DEBUG = env("DJANGO_DEBUG")
 


### PR DESCRIPTION
## Description

This PR adds production-focused hardening to Django settings for deployments behind Nginx/reverse proxies, while keeping local development behavior safe.

### What changed

- Added reverse-proxy/security environment settings:
  - `DJANGO_CSRF_TRUSTED_ORIGINS`
  - `DJANGO_SECURE_PROXY_SSL_HEADER`
  - `DJANGO_USE_X_FORWARDED_HOST`
  - `DJANGO_SECURE_SSL_REDIRECT`
  - `DJANGO_SESSION_COOKIE_SECURE`
  - `DJANGO_CSRF_COOKIE_SECURE`
  - `DJANGO_SECURE_HSTS_SECONDS`
  - `DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS`
  - `DJANGO_SECURE_HSTS_PRELOAD`
- Added `.env` auto-loading from project root for local `manage.py` convenience.
- Added `_split_csv()` helper and used it for host/origin parsing.
- Added optional `policylens.apps.console` app loading (if present).
- Added `STATIC_ROOT` for production `collectstatic`.
- Applied security defaults:
  - proxy SSL header support
  - CSRF trusted origins parsing
  - secure cookie flags (with `DEBUG`-aware local behavior)
  - optional HTTPS redirect and HSTS controls
  - `SECURE_CONTENT_TYPE_NOSNIFF`, `X_FRAME_OPTIONS`, `SECURE_REFERRER_POLICY`
- Updated type annotations in settings to modern built-in forms (`list[...]`, `tuple[...] | None`) to satisfy Ruff upgrades.

### Behavior notes

- Auth defaults now point to:
  - `LOGIN_URL = "/login/"`
  - `LOGIN_REDIRECT_URL = "/"`
- In `DEBUG=True`, secure cookie and SSL redirect settings remain disabled for local non-TLS development.

### Validation

- `docker compose exec web python -m black . --check` passed.
- `docker compose exec web python -m ruff check .` passed.
- `docker compose exec web pytest -q --cov=policylens --cov-report=term-missing --cov-report=xml --cov-fail-under=80` passed (`187 passed`, `94.52%` total coverage).