### PR TITLE
fix(docker): avoid collectstatic permission issue in prod entrypoint

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -19,6 +19,7 @@ COPY . /app
 
 # Create a non-root user for production containers.
 RUN useradd --create-home --shell /bin/bash appuser \
+  && mkdir -p /app/staticfiles /app/media /app/artifacts \
   && chmod +x /app/docker/entrypoint.prod.sh \
   && chown -R appuser:appuser /app
 

--- a/docker/entrypoint.prod.sh
+++ b/docker/entrypoint.prod.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env sh
 set -eu
 
-if [ "${DJANGO_RUN_MIGRATIONS:-1}" = "1" ]; then
-  python manage.py migrate --noinput
-fi
+if [ "${1:-}" = "gunicorn" ]; then
+  if [ "${DJANGO_RUN_MIGRATIONS:-1}" = "1" ]; then
+    python manage.py migrate --noinput
+  fi
 
-if [ "${DJANGO_COLLECTSTATIC:-1}" = "1" ]; then
-  python manage.py collectstatic --noinput
+  if [ "${DJANGO_COLLECTSTATIC:-1}" = "1" ]; then
+    python manage.py collectstatic --noinput
+  fi
 fi
 
 exec "$@"


### PR DESCRIPTION
## Summary
This PR fixes a production Docker startup issue where `collectstatic` could fail with `PermissionError` and where one-off management commands unintentionally triggered startup tasks.

## Root Cause
- `docker/entrypoint.prod.sh` always ran `migrate` and `collectstatic`, even for commands like `python manage.py migrate`.
- `/app/staticfiles` (and other runtime dirs) could be mounted without writable ownership for `appuser`.

## Changes
- Updated [`docker/Dockerfile.prod`](/Users/adrianadewunmi/VSCODE/Claims-Fraud-Risk-Scoring-Project/docker/Dockerfile.prod):
  - Pre-create `/app/staticfiles`, `/app/media`, and `/app/artifacts`
  - Ensure ownership is set to `appuser` before runtime
- Updated [`docker/entrypoint.prod.sh`](/Users/adrianadewunmi/VSCODE/Claims-Fraud-Risk-Scoring-Project/docker/entrypoint.prod.sh):
  - Run `migrate` and `collectstatic` only when launching `gunicorn`
  - Preserve normal behavior for one-off management commands

## Impact
- `docker compose run --rm web python manage.py ...` now behaves as expected without side effects from the entrypoint.
- Production startup via Gunicorn still runs migration/static collection automatically (configurable via env flags).

## Validation
- Reproduced and resolved the previous `PermissionError` on static collection.
- `sh -n docker/entrypoint.prod.sh` passes.
- Prod stack commands run with corrected entrypoint flow.