### PR TITLE
docs: update deployment and runbook documentation for secure Docker profile

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -28,6 +28,14 @@ These must be set in the production runtime environment:
 - DATABASE_URL
 - DJANGO_CSRF_TRUSTED_ORIGINS
 
+## Secure compose profile
+
+For the secure Docker profile (`docker/docker-compose.prod.secure.yml`):
+
+- `.env.prod` is ignored by `.gitignore` (`.env.*`) and is not committed.
+- Replace all placeholder values in `.env.prod` before deployment.
+- Launch with `docker compose -f docker/docker-compose.prod.secure.yml up --build`.
+
 ## Reverse proxy and HTTPS detection
 
 Django must understand that the external client connection is HTTPS even though Nginx forwards requests to Django over HTTP. This is required for secure cookies, CSRF, and correct redirect behaviour.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,66 @@
+# path: docs/RUNBOOK.md
+# PolicyLens production stack runbook
+
+This runbook proves that PolicyLens runs behind an Nginx reverse proxy with Gunicorn, and that querystring pagination survives the proxy path. The checks are designed to match Sprint 7 expectations, where the demo is repeatable and surfaces behave consistently.
+
+## Pre-flight
+
+PolicyLens currently has two production-oriented compose profiles:
+
+- `docker/docker-compose.prod.yml` for local smoke validation on HTTP (`localhost:8080`)
+- `docker/docker-compose.prod.secure.yml` for secure production-style settings
+
+Important:
+
+- `.env.prod` is ignored by `.gitignore` (`.env.*`), so it exists locally but is not tracked in git.
+- Replace placeholder values in `.env.prod` before deployment.
+- Run `docker compose -f docker/docker-compose.prod.secure.yml up --build` to launch the secure profile.
+
+## Start the production stack
+
+```bash
+docker compose -f docker/docker-compose.prod.yml up --build -d
+```
+
+## Secure profile launch
+
+```bash
+docker compose -f docker/docker-compose.prod.secure.yml up --build
+```
+
+## Smoke checks
+
+Run these once the stack is up:
+
+```bash
+curl -i http://localhost:8080/api/health/
+```
+
+Expected:
+
+- HTTP `200`
+- JSON body contains `"status": "ok"`
+
+### Surface checks
+
+- `http://localhost:8080/login/admin/`
+- `http://localhost:8080/login/reviewer/`
+- `http://localhost:8080/login/customer/`
+- `http://localhost:8080/ops/queue/?page=2`
+- `http://localhost:8080/customer/?page=2`
+
+## One-off admin commands
+
+For one-off commands (migrations, seeding, etc.), use `run --rm`:
+
+```bash
+docker compose -f docker/docker-compose.prod.yml run --rm web python manage.py migrate --noinput
+```
+
+Note: the production entrypoint runs migrations and `collectstatic` automatically only when starting Gunicorn, not for one-off `manage.py` commands.
+
+## Stop the stack
+
+```bash
+docker compose -f docker/docker-compose.prod.yml down
+```


### PR DESCRIPTION
## Summary
Updates deployment documentation to reflect the secure Docker production profile and current production stack behavior.

## What Changed
- Updated [`docs/DEPLOYMENT.md`](/Users/adrianadewunmi/VSCODE/Claims-Fraud-Risk-Scoring-Project/docs/DEPLOYMENT.md):
  - Added a **Secure compose profile** section for `docker/docker-compose.prod.secure.yml`
  - Documented that `.env.prod` is ignored by `.gitignore` (`.env.*`) and must be maintained locally
  - Added guidance to replace placeholder values in `.env.prod` before deployment
  - Added secure profile launch command:
    - `docker compose -f docker/docker-compose.prod.secure.yml up --build`

- Rewrote [`docs/RUNBOOK.md`](/Users/adrianadewunmi/VSCODE/Claims-Fraud-Risk-Scoring-Project/docs/RUNBOOK.md) into a complete, clean runbook:
  - Clarifies local smoke vs secure production profile
  - Adds start/stop commands, health checks, route checks, and browser pagination checks
  - Includes one-off command guidance (`run --rm`) and entrypoint behavior note
  - Removes broken/duplicated formatting and incomplete sections

## Why
- Align docs with the new production Docker stack and secure deployment workflow
- Prevent confusion around `.env.prod` tracking and secure launch steps
- Provide a repeatable validation path for proxy, health, and pagination behavior

## Scope
- Documentation-only change
- No application runtime logic changes