### PR TITLE
docs(readme): add repository structure section with key project directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,34 @@ Key modules:
 - `policylens/apps/customer/` customer workflow surface
 - `policylens/apps/api/` top-level API wiring and health endpoint
 
+## Repository Structure
+
+```text
+.
+├── policylens/
+│   ├── apps/
+│   │   ├── accounts/        # auth/login surfaces
+│   │   ├── api/             # top-level API routes and health
+│   │   ├── claims/          # claims domain, APIs, queue, export, ML
+│   │   ├── console/         # role-specific console views
+│   │   ├── core/            # shared authz/idempotency/pagination utilities
+│   │   ├── customer/        # customer-facing workflows
+│   │   ├── ops/             # reviewer ops UI + HTMX endpoints
+│   │   └── public/          # public landing routes/views
+│   ├── config/              # Django settings, URL config, ASGI/WSGI
+│   ├── templates/           # shared templates
+│   └── static/              # shared static assets
+├── tests/                   # pytest suite (API, UI, ML, authz, SLA)
+├── docs/                    # deployment, runbook, demo and syllabus docs
+├── docker/                  # production Dockerfiles, nginx, gunicorn config
+├── scripts/                 # helper scripts (for demos/local workflows)
+├── artifacts/               # generated artifacts/evidence output
+├── media/                   # uploaded files (local/dev)
+├── docker-compose.yml       # local dev stack
+├── Dockerfile               # local/dev image build
+└── manage.py                # Django management entrypoint
+```
+
 ## Local Development
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
Adds a new `Repository Structure` section to the README to provide a quick, high-level map of the codebase.

## What Changed
- Added `## Repository Structure` to `README.md`.
- Included a concise tree view of major folders and root files.
- Added short purpose notes for key paths, including:
  - `policylens/apps/*` modules
  - `policylens/config`, `templates`, `static`
  - `tests`, `docs`, `docker`, `scripts`
  - `artifacts`, `media`
  - `docker-compose.yml`, `Dockerfile`, `manage.py`

## Why
- Improves onboarding by helping contributors find code quickly.
- Reduces time spent navigating unfamiliar directories.
- Makes project organization explicit in a single reference point.

## Scope
- Documentation-only change (`README.md`).
- No runtime behavior, API contract, or infrastructure logic changed.

## Testing
- Not applicable (README-only update).